### PR TITLE
Add mac/linux support, add support for custom controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ SupportsRulesEngine : True
 
 ```
 
+### Using custom controller (self hosted)
+
+Grab your authtoken from the controllers authtoken.secret
+
+```powershell
+
+PS > $zturl="http://yourcontrollerurl/api"
+
+```
+
+
 ## References
 
 [ZeroTier API Help](https://my.zerotier.com/help/api)

--- a/ZeroTierController.psm1
+++ b/ZeroTierController.psm1
@@ -3,8 +3,9 @@
 if($Global:zturl){ #if variable zturl is set, treat this as a custom controller
     [string]$Url=$zturl
     [bool]$customcontroller=$true
+}else{
+    [string]$Url = "https://my.zerotier.com/api"
 }
-[string]$Url = "https://my.zerotier.com/api"
 #setup token paths
 if($IsLinux -or $IsMacOS){
     [string]$TokenPath = "$env:HOME/.zerotier-api-token"

--- a/ZeroTierController.psm1
+++ b/ZeroTierController.psm1
@@ -2,7 +2,6 @@
 #custom controller
 if($Global:zturl){ #if variable zturl is set, treat this as a custom controller
     [string]$Url=$zturl
-    [bool]$customcontroller=$true
 }else{
     [string]$Url = "https://my.zerotier.com/api"
 }
@@ -170,16 +169,7 @@ function Invoke-ZTAPI {
         $Body = $Body | ConvertTo-Json -Depth 10
         Write-Debug "Post $Body"
     }
-    if($customcontroller){
-        $apiargs = @{
-            Uri         = "$Url$Path"
-            Headers     = @{ "X-ZT1-Auth" = "$(Get-ZTToken)" } #with custom controller token from authtoken.secret is used.
-            Method      = $Method
-            Body        = $Body
-            ContentType = 'application/json'
-            ErrorAction = 'Stop'
-        }
-    }else{
+
         $apiargs = @{
             Uri         = "$Url$Path"
             Headers     = @{ "Authorization" = "Bearer $(Get-ZTToken)" }
@@ -188,9 +178,6 @@ function Invoke-ZTAPI {
             ContentType = 'application/json'
             ErrorAction = 'Stop'
         }
-    }
-
-    
 
     try {
         # Do the magic

--- a/ZeroTierController.psm1
+++ b/ZeroTierController.psm1
@@ -1,6 +1,12 @@
 ﻿# Settings
 [string]$Url = "https://my.zerotier.com/api"
-[string]$TokenPath = "$env:USERPROFILE\.zerotier-api-token"
+if($IsLinux -or $IsMacOS){
+    [string]$TokenPath = "$env:HOME/.zerotier-api-token"
+}else{
+    #windows
+    [string]$TokenPath = "$env:USERPROFILE\.zerotier-api-token"
+}
+
 
 # Definitions
 [string]$Node = ""

--- a/ZeroTierController.psm1
+++ b/ZeroTierController.psm1
@@ -1,5 +1,11 @@
 ﻿# Settings
+#custom controller
+if($Global:zturl){ #if variable zturl is set, treat this as a custom controller
+    [string]$Url=$zturl
+    [bool]$customcontroller=$true
+}
 [string]$Url = "https://my.zerotier.com/api"
+#setup token paths
 if($IsLinux -or $IsMacOS){
     [string]$TokenPath = "$env:HOME/.zerotier-api-token"
 }else{
@@ -163,15 +169,26 @@ function Invoke-ZTAPI {
         $Body = $Body | ConvertTo-Json -Depth 10
         Write-Debug "Post $Body"
     }
-
-    $apiargs = @{
-        Uri         = "$Url$Path"
-        Headers     = @{ "Authorization" = "Bearer $(Get-ZTToken)" }
-        Method      = $Method
-        Body        = $Body
-        ContentType = 'application/json'
-        ErrorAction = 'Stop'
+    if($customcontroller){
+        $apiargs = @{
+            Uri         = "$Url$Path"
+            Headers     = @{ "X-ZT1-Auth" = "$(Get-ZTToken)" } #with custom controller token from authtoken.secret is used.
+            Method      = $Method
+            Body        = $Body
+            ContentType = 'application/json'
+            ErrorAction = 'Stop'
+        }
+    }else{
+        $apiargs = @{
+            Uri         = "$Url$Path"
+            Headers     = @{ "Authorization" = "Bearer $(Get-ZTToken)" }
+            Method      = $Method
+            Body        = $Body
+            ContentType = 'application/json'
+            ErrorAction = 'Stop'
+        }
     }
+
     
 
     try {


### PR DESCRIPTION
-mac/linux needs a diffrent path for the token storage path
- custom controllers uses a diffrent auth header